### PR TITLE
Fix the bug when FLAnimatedImageView firstly show one EXIF rotation J…

### DIFF
--- a/FLAnimatedImage/FLAnimatedImageView.m
+++ b/FLAnimatedImage/FLAnimatedImageView.m
@@ -101,6 +101,9 @@
 {
     if (![_animatedImage isEqual:animatedImage]) {
         if (animatedImage) {
+            // UIImageView's `setImage:`, will internally call layer's `setContentsTransoforms:` based on the image.imageOrientation. The `contentsTransoforms` will effect layer rendering rotation because the CGImage's bitmap buffer does not actually take rotation.
+            // However, when call `setImage:nil`, this `contentsTransoforms` will not be reset to identity. Further animation frame will rendered as rotated. So we must firstlly call it with the poster image to clear the previous state
+            super.image = animatedImage.posterImage;
             // Clear out the image.
             super.image = nil;
             // Ensure disabled highlighting; it's not supported (see `-setHighlighted:`).


### PR DESCRIPTION
…PEG `UIImage`, later animated GIF `FLAnimatedImage` will also be rotated